### PR TITLE
bump version to 1.1.1

### DIFF
--- a/stack_strings.nimble
+++ b/stack_strings.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.1.0"
+version       = "1.1.1"
 author        = "termer"
 description   = "Library for guaranteed zero heap allocation strings"
 license       = "MIT"


### PR DESCRIPTION
948796c6b91c8e9684c17edc2d3c7586c511b405 fixed compilation but was made after the last version change, so nimble doesn't currently pick it up.